### PR TITLE
Initial upload of R07 ERR02 J.java: Prevent exceptions while logging data

### DIFF
--- a/R07_ERR02_J.java
+++ b/R07_ERR02_J.java
@@ -1,0 +1,13 @@
+/******************************************************************************
+ * Rule 07. Exceptional Behavior (ERR)
+ * ERR02-J. Prevent exceptions while logging data
+ * Exceptions that are thrown while logging is in progress can prevent successful logging unless special care is taken. 
+ * Failure to account for exceptions during the logging process can cause security vulnerabilities.
+ ******************************************************************************/
+
+ try {
+  // ...
+} catch (SecurityException se) {
+  System.err.println(se);
+  // Recover from exception
+}


### PR DESCRIPTION
Exceptions that are thrown while logging is in progress can prevent successful logging unless special care is taken. Failure to account for exceptions during the logging process can cause security vulnerabilities, such as allowing an attacker to conceal critical security exceptions by preventing them from being logged. Consequently, programs must ensure that data logging continues to operate correctly even when exceptions are thrown during the logging process.